### PR TITLE
feat: add debug mode and default SARIF/summary output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,19 +64,9 @@ struct Args {
     #[arg(long)]
     vuln_types: Option<String>,
 
-    /// サマリーレポートを生成する
-    #[arg(long)]
-    summary: bool,
-
     /// カスタムパターンを生成する（現在のディレクトリを解析してセキュリティパターンを自動検出）
     #[arg(long)]
     generate_patterns: bool,
-
-    /// SARIF形式で出力する
-    #[arg(long)]
-    sarif: bool,
-
-
 }
 
 #[tokio::main]
@@ -324,7 +314,8 @@ async fn main() -> Result<()> {
         filtered_summary = filtered_summary.filter_by_vuln_types(&vuln_types);
     }
 
-    if args.summary {
+    // Always generate summary report
+    {
         if let Some(ref final_output_dir) = output_dir {
             if let Err(e) = std::fs::create_dir_all(final_output_dir) {
                 println!(
@@ -352,8 +343,8 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Generate SARIF report if requested
-    if args.sarif {
+    // Always generate SARIF report
+    {
         let sarif_report = SarifReport::from_analysis_summary(&filtered_summary);
         
         if let Some(ref final_output_dir) = output_dir {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ struct Args {
     /// カスタムパターンを生成する（現在のディレクトリを解析してセキュリティパターンを自動検出）
     #[arg(long)]
     generate_patterns: bool,
+
+    /// Debug mode (save LLM input/output to debug folder)
+    #[arg(long)]
+    debug: bool,
 }
 
 #[tokio::main]
@@ -164,6 +168,7 @@ async fn main() -> Result<()> {
     let model = args.model.clone();
     let files = files.clone();
     let verbosity = args.verbosity;
+    let debug = args.debug;
 
     let mut summary = AnalysisSummary::new();
 
@@ -186,6 +191,7 @@ async fn main() -> Result<()> {
             let model = model.clone();
             let files = files.clone();
             let progress_bar = progress_bar.clone();
+            let debug = debug;
 
             async move {
                 let file_name = file_path.display().to_string();
@@ -217,7 +223,7 @@ async fn main() -> Result<()> {
                 };
 
                 let analysis_result =
-                    match analyze_file(&file_path, &model, &files, verbosity, &context, 0).await {
+                    match analyze_file(&file_path, &model, &files, verbosity, &context, 0, debug, &output_dir).await {
                         Ok(res) => res,
                         Err(e) => {
                             if verbosity > 0 {


### PR DESCRIPTION
## Summary
- Add debug mode to save LLM input/output to debug folder for better troubleshooting
- Make SARIF and summary report generation the default behavior (no longer behind flags)

## Test plan
- [ ] Verify debug mode saves LLM prompts and responses when --debug flag is used
- [ ] Confirm SARIF and summary reports are generated by default
- [ ] Test that debug files are properly timestamped and organized

🤖 Generated with [Claude Code](https://claude.ai/code)