### PR TITLE
feat: Add custom API base URL support

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -47,6 +47,9 @@ pub struct Args {
 
     #[arg(long)]
     pub debug: bool,
+
+    #[arg(long)]
+    pub api_base_url: Option<String>,
 }
 
 pub fn validate_output_directory(output_dir: &PathBuf) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,11 @@ async fn main() -> Result<()> {
 
     validate_args(&args)?;
 
+    // Get API base URL from CLI arg or environment variable
+    let env_base_url = std::env::var("API_BASE_URL").ok();
+    let api_base_url = args.api_base_url.as_deref()
+        .or_else(|| env_base_url.as_deref());
+
     let (root_dir, repo_name) = if let Some(repo) = &args.repo {
         let dest = PathBuf::from("repo");
         if dest.exists() {
@@ -76,7 +81,7 @@ async fn main() -> Result<()> {
     // Handle pattern generation mode
     if args.generate_patterns {
         println!("🔧 カスタムパターン生成モードを開始します");
-        generate_custom_patterns(&root_dir, &args.model).await?;
+        generate_custom_patterns(&root_dir, &args.model, api_base_url).await?;
         println!("✅ パターン生成が完了しました\n");
     }
 
@@ -184,7 +189,7 @@ async fn main() -> Result<()> {
                 };
 
                 let analysis_result =
-                    match analyze_file(&file_path, &model, &files, verbosity, &context, 0, debug, &output_dir).await {
+                    match analyze_file(&file_path, &model, &files, verbosity, &context, 0, debug, &output_dir, api_base_url).await {
                         Ok(res) => res,
                         Err(e) => {
                             if verbosity > 0 {

--- a/tests/analyzer_test.rs
+++ b/tests/analyzer_test.rs
@@ -21,6 +21,9 @@ async fn test_analyze_empty_file() -> anyhow::Result<()> {
             definitions: vec![],
         },
         0,
+        false,
+        &None,
+        None,
     )
     .await?;
 
@@ -57,6 +60,9 @@ fn main() {
             definitions: vec![],
         },
         0,
+        false,
+        &None,
+        None,
     )
     .await?;
 
@@ -105,6 +111,9 @@ fn main() {
             definitions: vec![],
         },
         0,
+        false,
+        &None,
+        None,
     )
     .await?;
 

--- a/tests/prompt_accuracy_unit_test.rs
+++ b/tests/prompt_accuracy_unit_test.rs
@@ -238,7 +238,7 @@ async fn test_individual_function_accuracy(test_case: &AccuracyTestCase, model: 
         let pattern_accuracy = if detected_as_security_risk && test_case.expected_pattern.is_some() {
             let definitions_slice = vec![definition];
             let patterns = parsentry::pattern_generator::analyze_definitions_for_security_patterns(
-                model, &definitions_slice, test_case.language
+                model, &definitions_slice, test_case.language, None
             ).await?;
             
             if let Some(pattern) = patterns.first() {

--- a/tests/prompt_benchmark_test.rs
+++ b/tests/prompt_benchmark_test.rs
@@ -258,7 +258,7 @@ async fn run_risk_assessment_benchmark(model: &str) -> Result<BenchmarkResults> 
             // Test pattern classification if function was kept
             let actual_pattern = if !high_risk_definitions.is_empty() {
                 let patterns = parsentry::pattern_generator::analyze_definitions_for_security_patterns(
-                    model, &high_risk_definitions, test_case.language
+                    model, &high_risk_definitions, test_case.language, None
                 ).await?;
                 patterns.first().map(|p| p.pattern_type.clone()).flatten()
             } else {
@@ -413,7 +413,7 @@ function handleUserLogin(req, res) {
             
             if risk_identified {
                 let patterns = parsentry::pattern_generator::analyze_definitions_for_security_patterns(
-                    model, &high_risk_definitions, test_case.language
+                    model, &high_risk_definitions, test_case.language, None
                 ).await?;
                 let pattern_type = patterns.first().map(|p| p.pattern_type.clone()).flatten();
                 pattern_results.push(pattern_type);

--- a/tests/prompt_slo_test.rs
+++ b/tests/prompt_slo_test.rs
@@ -354,7 +354,7 @@ pub async fn run_slo_compliance_test(model: &str, slo: &PromptSLO) -> Result<SLO
             // Test pattern classification
             let actual_pattern_type = if !high_risk_definitions.is_empty() {
                 let patterns = parsentry::pattern_generator::analyze_definitions_for_security_patterns(
-                    model, &high_risk_definitions, test_case.language
+                    model, &high_risk_definitions, test_case.language, None
                 ).await?;
                 
                 patterns.first().and_then(|p| {
@@ -558,7 +558,7 @@ function authenticateUser(username, password) {
             
             let pattern_type = if !high_risk_definitions.is_empty() {
                 let patterns = parsentry::pattern_generator::analyze_definitions_for_security_patterns(
-                    model, &high_risk_definitions, test_case.language
+                    model, &high_risk_definitions, test_case.language, None
                 ).await?;
                 patterns.first().and_then(|p| p.pattern_type.clone())
             } else {


### PR DESCRIPTION
## Summary
Add support for configuring custom API base URLs through CLI arguments and environment variables to enable integration with different AI providers and self-hosted API endpoints.

## Features
- `--api-base-url` CLI argument for custom endpoint configuration
- `API_BASE_URL` environment variable support
- CLI argument takes precedence over environment variable
- Uses genai crate's ServiceTargetResolver for proper routing
- Maintains compatibility with existing model auto-detection
- Works with both analyzer and pattern generator modules

## Usage Examples
```bash
# Via CLI argument
parsentry --repo owner/repo --api-base-url "https://custom.api.example.com/v1"

# Via environment variable
API_BASE_URL="https://custom.api.example.com/v1" parsentry --repo owner/repo

# CLI takes precedence over environment
API_BASE_URL="https://env.url.com" parsentry --repo owner/repo --api-base-url "https://cli.url.com"
```

## Test Plan
- [x] Compilation passes
- [x] CLI argument functionality tested
- [x] Environment variable functionality tested
- [x] CLI precedence over environment variable verified
- [x] Custom URL logging works correctly
- [x] All existing tests updated and passing

Fixes #87

🤖 Generated with [Claude Code](https://claude.ai/code)