### PR TITLE
improve: Force OpenAI adapter for custom base URLs

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use genai::chat::{ChatMessage, ChatOptions, ChatRequest, JsonSpec};
 use genai::{Client, ClientConfig};
 use genai::resolver::{Endpoint, ServiceTargetResolver};
-use genai::ServiceTarget;
+use genai::{ServiceTarget, ModelIden, adapter::AdapterKind};
 use log::{debug, error, info, warn};
 use regex::escape;
 use serde::de::DeserializeOwned;
@@ -70,8 +70,11 @@ fn create_custom_target_resolver(base_url: &str) -> ServiceTargetResolver {
         move |service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
             let ServiceTarget { model, auth, .. } = service_target;
             
-            // Use the custom base URL while keeping the original model identifier
+            // Use the custom base URL and force OpenAI adapter for compatibility
             let endpoint = Endpoint::from_owned(base_url_owned.clone());
+            
+            // When using custom base URL, assume OpenAI-compatible API
+            let model = ModelIden::new(AdapterKind::OpenAI, model.model_name);
             
             Ok(ServiceTarget { endpoint, auth, model })
         },

--- a/src/pattern_generator.rs
+++ b/src/pattern_generator.rs
@@ -3,7 +3,7 @@ use futures::stream::{self, StreamExt};
 use genai::chat::{ChatMessage, ChatOptions, ChatRequest, JsonSpec};
 use genai::{Client, ClientConfig};
 use genai::resolver::{Endpoint, ServiceTargetResolver};
-use genai::ServiceTarget;
+use genai::{ServiceTarget, ModelIden, adapter::AdapterKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 #[allow(unused_imports)]
@@ -62,8 +62,11 @@ fn create_pattern_target_resolver(base_url: &str) -> ServiceTargetResolver {
         move |service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
             let ServiceTarget { model, auth, .. } = service_target;
             
-            // Use the custom base URL while keeping the original model identifier
+            // Use the custom base URL and force OpenAI adapter for compatibility
             let endpoint = Endpoint::from_owned(base_url_owned.clone());
+            
+            // When using custom base URL, assume OpenAI-compatible API
+            let model = ModelIden::new(AdapterKind::OpenAI, model.model_name);
             
             Ok(ServiceTarget { endpoint, auth, model })
         },


### PR DESCRIPTION
## Summary
Improve custom base URL functionality by forcing the use of OpenAI adapter for better compatibility with OpenAI-compatible APIs.

## Problem Solved
When using custom base URLs with certain model names (e.g., `openai/gpt-3.5-turbo`), the genai crate's automatic provider detection was incorrectly identifying them as other adapters (like Ollama), causing API compatibility issues.

## Solution
- Force `AdapterKind::OpenAI` when custom base URL is provided
- Ensures proper compatibility with OpenAI-compatible APIs like OpenRouter, Ollama, and other providers
- Maintains backward compatibility with default behavior

## Changes
- Updated `create_custom_target_resolver` in both `analyzer.rs` and `pattern_generator.rs`
- Added explicit OpenAI adapter forcing for custom base URLs
- Maintains original model names for API compatibility

## Testing
✅ Tested with OpenRouter API endpoint  
✅ Confirmed proper adapter detection: `openai/gpt-3.5-turbo (adapter: OpenAI)`  
✅ No breaking changes to existing functionality

## Usage
Works automatically when using custom base URLs:
```bash
# Now correctly uses OpenAI adapter regardless of model name
parsentry --api-base-url "https://openrouter.ai/api/v1" --model "openai/gpt-3.5-turbo"
```

🤖 Generated with [Claude Code](https://claude.ai/code)