### PR TITLE
fix: pattern_generatorでreferencesが検出されない問題を修正

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -392,7 +392,7 @@ impl Response {
 
     pub fn to_markdown(&self) -> String {
         let mut md = String::new();
-        md.push_str("# PAR Security Analysis Report\n\n");
+        md.push_str("# Analysis Report\n\n");
 
         let confidence_badge = match self.confidence_score {
             90..=100 => "![高信頼度](https://img.shields.io/badge/信頼度-高-red)",

--- a/tests/response_unit_test.rs
+++ b/tests/response_unit_test.rs
@@ -160,7 +160,7 @@ fn test_markdown_generation() {
     let markdown = response.to_markdown();
 
     // Verify markdown contains expected sections
-    assert!(markdown.contains("# PAR Security Analysis Report"));
+    assert!(markdown.contains("# Analysis Report"));
     assert!(markdown.contains("信頼度スコア: 8"));
     assert!(markdown.contains("## 脆弱性タイプ"));
     assert!(markdown.contains("RCE"));


### PR DESCRIPTION
- extract_references_from_file関数を追加してreferences抽出を実装
- tree-sitterのreferences queryを使用して参照を検出
- references検出結果の出力ログを追加
- StreamingIteratorのimportを追加
- analyzer.rs: AuthData importとcustom resolver改善
- response.rs: Markdownタイトルを'Analysis Report'に変更
- tests: タイトル変更に伴うテスト更新