### PR TITLE
fix: カスタムURL使用時のAPI KEY認証問題を修正 (#92)

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -78,11 +78,13 @@ fn create_custom_target_resolver(base_url: &str) -> ServiceTargetResolver {
             
             // Use OpenAI adapter but with custom endpoint that already includes the full path
             let model = ModelIden::new(AdapterKind::OpenAI, model.model_name);
-            let auth = None; // Let genai resolve OpenAI auth automatically
+            
+            // Use the OPENAI_API_KEY environment variable as the new key when using custom URL
+            let auth = AuthData::from_env("OPENAI_API_KEY");
             
             Ok(ServiceTarget {
                 endpoint,
-                auth: auth.unwrap_or_else(|| AuthData::from_env("OPENAI_API_KEY")),
+                auth,
                 model
             })
         },

--- a/src/pattern_generator.rs
+++ b/src/pattern_generator.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use genai::chat::{ChatMessage, ChatOptions, ChatRequest, JsonSpec};
 use genai::{Client, ClientConfig};
-use genai::resolver::{Endpoint, ServiceTargetResolver};
+use genai::resolver::{Endpoint, ServiceTargetResolver, AuthData};
 use genai::{ServiceTarget, ModelIden, adapter::AdapterKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -34,7 +34,7 @@ fn create_pattern_target_resolver(base_url: &str) -> ServiceTargetResolver {
     
     ServiceTargetResolver::from_resolver_fn(
         move |service_target: ServiceTarget| -> Result<ServiceTarget, genai::resolver::Error> {
-            let ServiceTarget { model, auth, .. } = service_target;
+            let ServiceTarget { model, .. } = service_target;
             
             // Use the custom base URL and force OpenAI adapter for compatibility
             let endpoint = Endpoint::from_owned(base_url_owned.clone());
@@ -42,6 +42,8 @@ fn create_pattern_target_resolver(base_url: &str) -> ServiceTargetResolver {
             // When using custom base URL, assume OpenAI-compatible API
             let model = ModelIden::new(AdapterKind::OpenAI, model.model_name);
             
+            // Use the OPENAI_API_KEY environment variable as the new key when using custom URL
+            let auth = AuthData::from_env("OPENAI_API_KEY");
             Ok(ServiceTarget { endpoint, auth, model })
         },
     )

--- a/tests/analyzer_test.rs
+++ b/tests/analyzer_test.rs
@@ -19,6 +19,7 @@ async fn test_analyze_empty_file() -> anyhow::Result<()> {
         0,
         &parsentry::parser::Context {
             definitions: vec![],
+            references: vec![],
         },
         0,
         false,
@@ -58,6 +59,7 @@ fn main() {
         0,
         &parsentry::parser::Context {
             definitions: vec![],
+            references: vec![],
         },
         0,
         false,
@@ -109,6 +111,7 @@ fn main() {
         0,
         &parsentry::parser::Context {
             definitions: vec![],
+            references: vec![],
         },
         0,
         false,


### PR DESCRIPTION
## Summary
- カスタムURL使用時にAPI KEYが正しく送信されない問題を修正
- "Bearer ollama"が常に使用される問題を解決
- `analyzer.rs`と`pattern_generator.rs`で認証処理を改善

## Changes
- `src/analyzer.rs`: カスタムURL使用時に`OPENAI_API_KEY`環境変数を明示的に使用
- `src/pattern_generator.rs`: 同様の認証修正と`AuthData`インポート追加
- `tests/analyzer_test.rs`: Context構造体に`references`フィールドを追加してコンパイルエラーを修正

## Test plan
- [x] コードのコンパイル確認
- [x] 基本テストの実行確認
- [x] 未使用変数の警告解消

## Fixes
Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)