### PR TITLE
feat: add comprehensive unit tests for parser.rs

### DIFF
--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1,0 +1,547 @@
+use anyhow::Result;
+use parsentry::parser::{CodeParser, Context, Definition};
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_code_parser_new() -> Result<()> {
+    let parser = CodeParser::new()?;
+    assert!(parser.files.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_add_file_success() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(&file_path, "fn main() {}")?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    assert_eq!(parser.files.len(), 1);
+    assert!(parser.files.contains_key(&file_path));
+    assert_eq!(parser.files.get(&file_path).unwrap(), "fn main() {}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_add_file_not_found() -> Result<()> {
+    let mut parser = CodeParser::new()?;
+    let non_existent_path = PathBuf::from("/non/existent/file.rs");
+
+    let result = parser.add_file(&non_existent_path);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("ファイルの読み込みに失敗しました")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_rust() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let rust_path = PathBuf::from("test.rs");
+    let language = parser.get_language(&rust_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_c() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let c_path = PathBuf::from("test.c");
+    let language = parser.get_language(&c_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_cpp() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let cpp_paths = vec!["test.cpp", "test.cxx", "test.cc", "test.hpp", "test.hxx"];
+
+    for path_str in cpp_paths {
+        let path = PathBuf::from(path_str);
+        let language = parser.get_language(&path);
+        assert!(language.is_some(), "Failed for extension: {}", path_str);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_python() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let python_path = PathBuf::from("test.py");
+    let language = parser.get_language(&python_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_javascript() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let js_path = PathBuf::from("test.js");
+    let language = parser.get_language(&js_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_typescript() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let ts_paths = vec!["test.ts", "test.tsx"];
+
+    for path_str in ts_paths {
+        let path = PathBuf::from(path_str);
+        let language = parser.get_language(&path);
+        assert!(language.is_some(), "Failed for extension: {}", path_str);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_java() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let java_path = PathBuf::from("test.java");
+    let language = parser.get_language(&java_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_go() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let go_path = PathBuf::from("test.go");
+    let language = parser.get_language(&go_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_ruby() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let ruby_path = PathBuf::from("test.rb");
+    let language = parser.get_language(&ruby_path);
+    assert!(language.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_terraform() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let tf_paths = vec!["test.tf", "test.hcl"];
+
+    for path_str in tf_paths {
+        let path = PathBuf::from(path_str);
+        let language = parser.get_language(&path);
+        assert!(language.is_some(), "Failed for extension: {}", path_str);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_php() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let php_paths = vec![
+        "test.php",
+        "test.php3",
+        "test.php4",
+        "test.php5",
+        "test.phtml",
+    ];
+
+    for path_str in php_paths {
+        let path = PathBuf::from(path_str);
+        let language = parser.get_language(&path);
+        assert!(language.is_some(), "Failed for extension: {}", path_str);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_language_unsupported() -> Result<()> {
+    let parser = CodeParser::new()?;
+    let unsupported_path = PathBuf::from("test.txt");
+    let language = parser.get_language(&unsupported_path);
+    assert!(language.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_query_content_through_file_operations() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(&file_path, "fn test_function() {}")?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    // Test through actual file operations to validate get_query_content indirectly
+    let result = parser.find_definition("test_function", &file_path)?;
+    assert!(
+        result.is_some(),
+        "Should find definition through query system"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_definition_simple_rust() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn hello_world() { println!(\"Hello, world!\"); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let result = parser.find_definition("hello_world", &file_path)?;
+    assert!(result.is_some());
+
+    let (found_path, definition) = result.unwrap();
+    assert_eq!(found_path, file_path);
+    assert_eq!(definition.name, "hello_world");
+    // The source should contain the function definition
+    assert!(
+        !definition.source.is_empty(),
+        "Definition source should not be empty"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_definition_not_found() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn hello_world() { println!(\"Hello, world!\"); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let result = parser.find_definition("non_existent_function", &file_path)?;
+    assert!(result.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_definition_file_not_in_parser() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(&file_path, "fn hello_world() {}")?;
+
+    let mut parser = CodeParser::new()?;
+    // Note: not adding file to parser
+
+    let result = parser.find_definition("hello_world", &file_path);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("パーサーにファイルが見つかりません")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_references_simple_rust() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn hello_world() { println!(\"Hello, world!\"); }\nfn main() { hello_world(); hello_world(); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let results = parser.find_references("hello_world")?;
+    assert!(!results.is_empty());
+
+    // Should find references in the main function
+    let references: Vec<_> = results
+        .iter()
+        .filter(|(_, def)| def.name == "hello_world")
+        .collect();
+    assert!(!references.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_references_no_matches() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn hello_world() { println!(\"Hello, world!\"); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let results = parser.find_references("non_existent_function")?;
+    assert!(results.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_bidirectional() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn hello_world() { println!(\"Hello, world!\"); }\nfn main() { hello_world(); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let results = parser.find_bidirectional("hello_world", &file_path)?;
+    assert!(!results.is_empty(), "Should find some results");
+
+    // At minimum, should find the definition or references
+    let has_definition = results
+        .iter()
+        .any(|(_, def)| def.source.contains("fn") || def.source.contains("{"));
+    let has_reference = results.iter().any(|(_, def)| def.name == "hello_world");
+
+    assert!(
+        has_definition || has_reference,
+        "Should find either definition or reference"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_build_context_from_file_rust() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    fs::write(
+        &file_path,
+        "fn helper() { println!(\"helper\"); }\nfn main() { helper(); }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let context = parser.build_context_from_file(&file_path)?;
+
+    assert!(!context.definitions.is_empty(), "Should find definitions");
+    assert!(!context.references.is_empty(), "Should find references");
+
+    // Check that we found the helper function definition
+    let helper_defs: Vec<_> = context
+        .definitions
+        .iter()
+        .filter(|def| def.name == "helper")
+        .collect();
+    assert!(
+        !helper_defs.is_empty(),
+        "Should find helper function definition"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_build_context_from_file_unsupported_language() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.txt");
+    fs::write(&file_path, "some text content")?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let context = parser.build_context_from_file(&file_path)?;
+
+    // For unsupported languages, should return empty context
+    assert!(context.definitions.is_empty());
+    assert!(context.references.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_build_context_from_file_missing_file() -> Result<()> {
+    let mut parser = CodeParser::new()?;
+    let non_existent_path = PathBuf::from("/non/existent/file.rs");
+
+    let result = parser.build_context_from_file(&non_existent_path);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("ファイルが見つかりません")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_definition_struct() -> Result<()> {
+    let def = Definition {
+        name: "test_function".to_string(),
+        start_byte: 0,
+        end_byte: 10,
+        source: "fn test_function() {}".to_string(),
+    };
+
+    assert_eq!(def.name, "test_function");
+    assert_eq!(def.start_byte, 0);
+    assert_eq!(def.end_byte, 10);
+    assert_eq!(def.source, "fn test_function() {}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_context_struct() -> Result<()> {
+    let def1 = Definition {
+        name: "func1".to_string(),
+        start_byte: 0,
+        end_byte: 10,
+        source: "fn func1() {}".to_string(),
+    };
+
+    let def2 = Definition {
+        name: "func2".to_string(),
+        start_byte: 20,
+        end_byte: 30,
+        source: "fn func2() {}".to_string(),
+    };
+
+    let context = Context {
+        definitions: vec![def1.clone()],
+        references: vec![def2.clone()],
+    };
+
+    assert_eq!(context.definitions.len(), 1);
+    assert_eq!(context.references.len(), 1);
+    assert_eq!(context.definitions[0].name, "func1");
+    assert_eq!(context.references[0].name, "func2");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multiple_files_references() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+
+    // Create first file with function definition
+    let file1_path = temp_dir.path().join("lib.rs");
+    fs::write(
+        &file1_path,
+        "pub fn shared_function() { println!(\"shared\"); }",
+    )?;
+
+    // Create second file that uses the function
+    let file2_path = temp_dir.path().join("main.rs");
+    fs::write(&file2_path, "fn main() { shared_function(); }")?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file1_path)?;
+    parser.add_file(&file2_path)?;
+
+    let references = parser.find_references("shared_function")?;
+
+    // Should find references across multiple files
+    assert!(!references.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_definition_with_malformed_code() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("malformed.rs");
+    fs::write(&file_path, "fn incomplete_function(")?; // Malformed Rust code
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    // Should handle malformed code gracefully
+    let result = parser.find_definition("incomplete_function", &file_path);
+    // This might fail to parse, but shouldn't panic
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_references_with_empty_file() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("empty.rs");
+    fs::write(&file_path, "")?; // Empty file
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let results = parser.find_references("any_function")?;
+    assert!(results.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_parser_with_large_function_name() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test.rs");
+    let long_name = "a".repeat(1000); // Very long function name
+    let code = format!("fn {}() {{}}", long_name);
+    fs::write(&file_path, code)?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let result = parser.find_definition(&long_name, &file_path)?;
+    if let Some((_, definition)) = result {
+        assert_eq!(definition.name, long_name);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_build_context_with_recursive_functions() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("recursive.rs");
+    fs::write(
+        &file_path,
+        "fn factorial(n: u32) -> u32 { if n <= 1 { 1 } else { n * factorial(n - 1) } }",
+    )?;
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let context = parser.build_context_from_file(&file_path)?;
+
+    // Should handle recursive function calls
+    assert!(!context.definitions.is_empty());
+    let factorial_defs: Vec<_> = context
+        .definitions
+        .iter()
+        .filter(|def| def.name == "factorial")
+        .collect();
+    assert!(!factorial_defs.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_parser_with_unicode_in_code() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("unicode.rs");
+    fs::write(&file_path, "fn こんにちは() { println!(\"世界\"); }")?; // Unicode function name
+
+    let mut parser = CodeParser::new()?;
+    parser.add_file(&file_path)?;
+
+    let result = parser.find_definition("こんにちは", &file_path)?;
+    assert!(result.is_some());
+
+    let (_, definition) = result.unwrap();
+    assert_eq!(definition.name, "こんにちは");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add 33 comprehensive test cases for the critical `parser.rs` module that previously had no test coverage
- Cover basic functionality, core parsing features, edge cases, and error handling
- Improve project stability by testing the tree-sitter based code analysis foundation

## Test Coverage Added
- **Basic functionality**: Parser initialization, file operations, multi-language support (11 languages)
- **Core features**: Definition search, reference search, bidirectional tracking, context building
- **Edge cases**: Malformed code, empty files, Unicode characters, large function names, recursive functions
- **Error handling**: Missing files, unsupported languages, graceful degradation

## Test plan
- [x] All 33 new tests pass
- [x] Existing tests continue to pass
- [x] Tests cover critical parsing operations used throughout the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)