### PR TITLE
feat: add PARSENTRY_DISABLE_V1_PATH for custom API endpoint control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,9 @@ cargo test
 # Run tests with snapshot testing
 cargo test --features snapshot-test
 
+# Run benchmarks
+cargo test --features benchmark
+
 # Update test snapshots
 cargo insta test
 cargo insta review


### PR DESCRIPTION
## Summary
- Added `PARSENTRY_DISABLE_V1_PATH` environment variable to control API endpoint path behavior
- When set, uses Groq adapter instead of OpenAI adapter to prevent automatic `/v1/chat/completions` path appending
- Enables support for custom API endpoints with non-standard path structures

## Technical Details

### Problem
The genai crate's OpenAI adapter automatically appends `/v1/chat/completions` to all base URLs. This causes issues when:
- Using custom API endpoints that already include the full path
- Connecting to non-OpenAI compatible APIs with different path structures
- Needing precise control over the exact API endpoint

### Solution
This PR introduces an environment variable `PARSENTRY_DISABLE_V1_PATH` that switches the adapter behavior:

| Adapter | Behavior | When to Use |
|---------|----------|-------------|
| `AdapterKind::OpenAI` (default) | Appends `/v1/chat/completions` to base URL | Standard OpenAI-compatible APIs |
| `AdapterKind::Groq` (with env var) | Uses URL as-is, no path appending | Custom endpoints with full URL |

### Implementation
The solution leverages the fact that different adapters in the genai crate have different URL handling behaviors:
- **OpenAI adapter**: Always appends `/v1/chat/completions`
- **Groq adapter**: Uses the provided URL without modification

By switching between these adapters based on the environment variable, we can control the final API endpoint without modifying the genai crate itself.

## Usage Examples

```bash
# Standard OpenAI-compatible endpoint (default behavior)
# Final URL: https://api.example.com/v1/chat/completions
cargo run -- --api-base-url https://api.example.com --repo owner/repo

# Custom endpoint with full path (new behavior)
# Final URL: https://api.example.com/custom/llm/endpoint
export PARSENTRY_DISABLE_V1_PATH=1
cargo run -- --api-base-url https://api.example.com/custom/llm/endpoint --repo owner/repo
```

## Test plan
- [x] Test with standard OpenAI-compatible endpoints (default behavior)
- [x] Test with custom endpoints using PARSENTRY_DISABLE_V1_PATH
- [x] Verify debug output shows correct adapter selection
- [x] Ensure no regression in default behavior

🤖 Generated with [Claude Code](https://claude.ai/code)