### PR TITLE
fix: remove benchmark requirement from core unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ required-features = ["benchmark"]
 [[test]]
 name = "analyzer_unit_test"
 path = "tests/analyzer_unit_test.rs"
-required-features = ["benchmark"]
 
 [[test]]
 name = "context_quality_accuracy_test"
@@ -87,7 +86,6 @@ required-features = ["benchmark"]
 [[test]]
 name = "prompt_accuracy_unit_test"
 path = "tests/prompt_accuracy_unit_test.rs"
-required-features = ["benchmark"]
 
 [[test]]
 name = "prompt_slo_test"


### PR DESCRIPTION
## Summary
- Removes benchmark feature requirement from `analyzer_unit_test.rs` and `prompt_accuracy_unit_test.rs`
- Improves test coverage in default `cargo test` execution
- Fixes core analyzer functionality tests being gated behind optional feature flag

## Fixes Issue #125

This addresses the critical feature flag misorganization where core analyzer functionality tests required the optional `benchmark` feature flag, resulting in incomplete test coverage in default CI/CD pipelines.

## Changes Made

### Phase 1: Immediate Fixes
1. **Removed benchmark requirement** from `analyzer_unit_test.rs` 
   - Contains true unit tests that mock API calls
   - Should always run as part of standard test suite
   
2. **Removed benchmark requirement** from `prompt_accuracy_unit_test.rs`
   - Contains unit tests that gracefully skip when API keys unavailable
   - Core functionality should be tested in default runs

## Impact

### Before Changes
- Default `cargo test` excluded essential analyzer unit tests
- Tests requiring `--features benchmark` to run core functionality tests
- Incomplete CI/CD coverage missing critical functionality validation

### After Changes  
- Essential unit tests now run in default `cargo test` execution
- Improved test coverage and developer experience
- Tests still skip gracefully when OPENAI_API_KEY is not available

## Test Plan
- [x] Verified `analyzer_unit_test.rs` runs successfully without API keys
- [x] Verified `prompt_accuracy_unit_test.rs` runs with proper skipping behavior
- [x] Confirmed increased test count in default `cargo test` execution
- [x] All core unit tests pass without requiring benchmark feature flag

## Notes

This implements **Phase 1** of the feature flag reorganization outlined in issue #125. This focuses on the immediate fixes for the most critical misclassified tests that were preventing core functionality from being tested in the default test suite.

Future phases could include more comprehensive feature flag restructuring (`core-tests`, `api-tests`, `benchmark`), but this change provides immediate value by ensuring core analyzer functionality is always tested.