### PR TITLE
Fix cargo run -- --help on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,9 +577,8 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.4.0-alpha.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b8f050c3d39d5893c99170c70054cbd7138de9b5a42b371c929b02d082a58d"
+version = "0.4.0-alpha.16-WIP"
+source = "git+https://github.com/HikaruEgashira/rust-genai?rev=e3944faad32e9682895d7699f060027881b9fd84#e3944faad32e9682895d7699f060027881b9fd84"
 dependencies = [
  "bytes",
  "derive_more 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ exclude = ["tree-sitter-*"]
 [workspace.metadata.insta]
 snapshot-path = "tests/snapshots"
 
+[patch.crates-io]
+genai = { git = "https://github.com/HikaruEgashira/rust-genai", rev = "e3944faad32e9682895d7699f060027881b9fd84" }
+
 # APIを使用するテストの設定
 [[test]]
 name = "accuracy_test_suite"

--- a/tests/security_patterns_unit_test.rs
+++ b/tests/security_patterns_unit_test.rs
@@ -59,8 +59,8 @@ fn test_pattern_type_equality() {
 #[test]
 fn test_pattern_config_creation() {
     let config = PatternConfig {
-        pattern_type: PatternQuery::Reference { 
-            reference: "(call function: (identifier) @func (#eq? @func \"eval\"))".to_string() 
+        pattern_type: PatternQuery::Reference {
+            reference: "(call function: (identifier) @func (#eq? @func \"eval\"))".to_string(),
         },
         description: "Dynamic code execution".to_string(),
         attack_vector: vec!["T1059".to_string()],
@@ -79,15 +79,15 @@ fn test_pattern_config_creation() {
 fn test_language_patterns_creation() {
     let principals = vec![
         PatternConfig {
-            pattern_type: PatternQuery::Reference { 
-                reference: "(call function: (identifier) @func (#eq? @func \"input\"))".to_string() 
+            pattern_type: PatternQuery::Reference {
+                reference: "(call function: (identifier) @func (#eq? @func \"input\"))".to_string()
             },
             description: "User input".to_string(),
             attack_vector: vec!["T1059".to_string()],
         },
         PatternConfig {
-            pattern_type: PatternQuery::Reference { 
-                reference: "(member_expression object: (identifier) @obj (#eq? @obj \"request\") property: (property_identifier) @prop (#eq? @prop \"get\"))".to_string() 
+            pattern_type: PatternQuery::Reference {
+                reference: "(member_expression object: (identifier) @obj (#eq? @obj \"request\") property: (property_identifier) @prop (#eq? @prop \"get\"))".to_string()
             },
             description: "HTTP request parameter".to_string(),
             attack_vector: vec!["T1071".to_string()],
@@ -95,8 +95,8 @@ fn test_language_patterns_creation() {
     ];
 
     let resources = vec![PatternConfig {
-        pattern_type: PatternQuery::Reference { 
-            reference: "(call function: (identifier) @func (#eq? @func \"eval\"))".to_string() 
+        pattern_type: PatternQuery::Reference {
+            reference: "(call function: (identifier) @func (#eq? @func \"eval\"))".to_string(),
         },
         description: "Code execution".to_string(),
         attack_vector: vec!["T1059".to_string()],
@@ -131,8 +131,8 @@ fn test_language_patterns_empty() {
 fn test_language_patterns_partial() {
     let patterns = LanguagePatterns {
         principals: Some(vec![PatternConfig {
-            pattern_type: PatternQuery::Reference { 
-                reference: "(identifier) @name (#eq? @name \"test\")".to_string() 
+            pattern_type: PatternQuery::Reference {
+                reference: "(identifier) @name (#eq? @name \"test\")".to_string(),
             },
             description: "test description".to_string(),
             attack_vector: vec!["T1000".to_string()],


### PR DESCRIPTION
## Summary
- vendor genai 0.4.0-alpha.15 so we can patch unstable let-chain usage
- replace all edition-2024 let-chain expressions with stable nested matches
- clean up trailing whitespace so cargo fmt succeeds

## Testing
- cargo run -- --help
