### PR TITLE
chore(security): harden GitHub Actions workflows with sisakulint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-lint-
 
       - name: Check formatting

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -61,25 +61,28 @@ jobs:
       - name: Get changed source files
         id: diff
         timeout-minutes: 2
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD \
+          FILES=$(git diff --name-only --diff-filter=ACMR "origin/${BASE_REF}...HEAD" \
             | grep -E '\.(py|js|ts|jsx|tsx|go|java|rb|rs|c|cpp|cs|php|swift|kt|scala|tf|hcl|yml|yaml|sh|sql|pl|pm|lua)$' \
             | head -200)
           if [ -z "$FILES" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "skip=false" >> $GITHUB_OUTPUT
-            echo "count=$(echo "$FILES" | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "count=$(echo "$FILES" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run scan
         if: steps.diff.outputs.skip != 'true'
         timeout-minutes: 20
-        run: |
-          parsentry scan . \
-            --diff-base origin/${{ github.base_ref }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          parsentry scan . \
+            --diff-base "origin/${BASE_REF}"
 
       - name: Upload reports
         if: steps.diff.outputs.skip != 'true'


### PR DESCRIPTION
Hardening from sisakulint scan.

## Changes
- **ci.yml**: add `github.sha` to lint cache key to prevent cache-poisoning via predictable PR cache (Dependabot pre-poisoning vector).
- **scan.yml**: bind `github.base_ref` to env var instead of direct expression interpolation in shell `run` blocks (defense-in-depth against expression injection).

## Verification
`sisakulint` reports 0 findings across all 5 workflows after this change.

## Workflows reviewed
- ci.yml, mutants.yml, release.yml, scan.yml, website.yml
- No AI-agent (claude-code/etc.) workflows present in repo, so ai-action-* rules N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores（保守作業）
* 開発インフラストラクチャの改善として、継続的インテグレーション（CI）ワークフローのキャッシュ機構を最適化し、セキュリティスキャンプロセスを強化しました。これらはバックエンド開発プロセスの効率化で、ユーザーへの直接的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->